### PR TITLE
test(mapping): add unit tests for Author and Book Mapping

### DIFF
--- a/src/Library.API/Mapping/DtoToModelProfile.cs
+++ b/src/Library.API/Mapping/DtoToModelProfile.cs
@@ -9,7 +9,11 @@ public class DtoToModelProfile : Profile
 {
     public DtoToModelProfile()
     {
-        CreateMap<SaveAuthorDto, Author>();
-        CreateMap<SaveBookDto, Book>();
+        CreateMap<SaveAuthorDto, Author>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.Books, opt => opt.Ignore());
+        CreateMap<SaveBookDto, Book>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.Author, opt => opt.Ignore());
     }
 }

--- a/tests/Library.API.Tests/Mapping/AuthorMappingTests.cs
+++ b/tests/Library.API.Tests/Mapping/AuthorMappingTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+
+using Library.API.Domain.Models;
+using Library.API.DTOs;
+
+namespace Library.API.Tests.Mapping;
+
+public class AuthorMappingTests : MappingTestsBase
+{
+    [Fact]
+    public void Should_Map_Author_To_AuthorDto()
+    {
+        // Arrange
+        var author = new Author
+        {
+            Id = 1,
+            Name = "Author 1",
+            BirthDate = new DateTime(1980, 1, 1),
+            Biography = "Author 1 is a science fiction author"
+        };
+
+        // Act
+        var result = Mapper.Map<AuthorDto>(author);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Id.Should().Be(author.Id);
+        result.Name.Should().Be(author.Name);
+        result.BirthDate.Should().Be(author.BirthDate);
+        result.Biography.Should().Be(author.Biography);
+    }
+
+    [Fact]
+    public void Should_Map_SaveAuthorDto_To_Author()
+    {
+        // Arrange
+        var authorDto = new SaveAuthorDto
+        {
+            Name = "Author 1",
+            BirthDate = new DateTime(1980, 1, 1),
+            Biography = "Author 1 is a science fiction author"
+        };
+
+        // Act
+        var result = Mapper.Map<Author>(authorDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be(authorDto.Name);
+        result.BirthDate.Should().Be(authorDto.BirthDate);
+        result.Biography.Should().Be(authorDto.Biography);
+    }
+}

--- a/tests/Library.API.Tests/Mapping/BookMappingTests.cs
+++ b/tests/Library.API.Tests/Mapping/BookMappingTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+
+using Library.API.Domain.Models;
+using Library.API.DTOs;
+
+namespace Library.API.Tests.Mapping;
+
+public class BookMappingTests : MappingTestsBase
+{
+    [Fact]
+    public void Should_Map_Book_To_BookDto()
+    {
+        // Arrange
+        var book = new Book
+        {
+            Id = 1,
+            Title = "Book 1",
+            Description = "Book 1 is a science fiction book"
+        };
+
+        // Act
+        var result = Mapper.Map<BookDto>(book);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Id.Should().Be(book.Id);
+        result.Title.Should().Be(book.Title);
+        result.Description.Should().Be(book.Description);   
+    }
+
+    [Fact]
+    public void Should_Map_SaveBookDto_To_Book()
+    {
+        // Arrange
+        var bookDto = new SaveBookDto
+        {
+            Title = "Book 1",
+            Description = "Book 1 is a science fiction book"
+        };
+
+        // Act
+        var result = Mapper.Map<Book>(bookDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Title.Should().Be(bookDto.Title);
+        result.Description.Should().Be(bookDto.Description);
+    }
+}

--- a/tests/Library.API.Tests/Mapping/MappingTestsBase.cs
+++ b/tests/Library.API.Tests/Mapping/MappingTestsBase.cs
@@ -1,0 +1,25 @@
+using AutoMapper;
+
+using Library.API.Mapping;
+
+namespace Library.API.Tests.Mapping;
+
+public class MappingTestsBase
+{
+    protected readonly IMapper Mapper;
+
+    public MappingTestsBase()
+    {
+        var configuration = new MapperConfiguration(cfg => {
+            cfg.AddProfile<DtoToModelProfile>();
+            cfg.AddProfile<ModelToDtoProfile>();
+        });
+        Mapper = configuration.CreateMapper();
+    }
+
+    [Fact] // private to not run on every test
+    private void Should_Have_Valid_Configuration()
+    {
+        Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+    }
+}


### PR DESCRIPTION
- Add unit tests for Author and Book mappings to ensure correct DTO-to-model and model-to-DTO conversions.
- Add MappingTestsBase to centralize AutoMapper configuration and validation for mapping tests.
- Update DtoToModelProfile to explicitly ignore unmapped properties.