### PR TITLE
fix(ci): update Docker build context and Dockerfile path in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,8 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
-        context: src/Library.API
+        context: .
+        file: src/Library.API/Dockerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Ensure the Docker build uses the project root as context and specifies the correct Dockerfile path